### PR TITLE
Tidy up Sparklines

### DIFF
--- a/examples/sparklines.py
+++ b/examples/sparklines.py
@@ -3,6 +3,7 @@ import logging
 import math
 import random
 import time
+from collections import deque
 from vindauga.constants.command_codes import cmQuit, hcNoContext
 from vindauga.constants.window_flags import wfClose
 from vindauga.constants.keys import kbAltF, kbAltX
@@ -58,10 +59,10 @@ class SparklineDialog(Dialog):
         # Initialize data
         self.randomWalkValue = 50
         self.stockValue = 100
-        self.sineData = []
-        self.randomData = []
-        self.stockData = []
-        self.multiData = []
+        self.sineData = deque(maxlen=100)
+        self.randomData = deque(maxlen=100)
+        self.stockData = deque(maxlen=100)
+        self.multiData = deque(maxlen=100)
 
         # Generate initial data
         for i in range(34):
@@ -85,31 +86,23 @@ class SparklineDialog(Dialog):
         # Update sine wave
         sineValue = 50 + 50 * math.sin(self.time * 0.2)
         self.sineData.append(sineValue)
-        if len(self.sineData) > 100:
-            self.sineData.pop(0)
         self.sparkSine.setData(self.sineData)
 
         # Update random walk
         self.randomWalkValue += random.uniform(-5, 5)
         self.randomWalkValue = max(0, min(100, self.randomWalkValue))
         self.randomData.append(self.randomWalkValue)
-        if len(self.randomData) > 100:
-            self.randomData.pop(0)
         self.sparkRandom.setData(self.randomData)
 
         # Update stock price
         change = random.uniform(-2, 2)
         self.stockValue *= (1 + change / 100)
         self.stockData.append(self.stockValue)
-        if len(self.stockData) > 100:
-            self.stockData.pop(0)
         self.sparkStock.setData(self.stockData)
 
         # Update multi-line data
         multiValue = 50 + 40 * math.sin(self.time * 0.3) + random.uniform(-10, 10)
         self.multiData.append(multiValue)
-        if len(self.multiData) > 100:
-            self.multiData.pop(0)
         self.sparkMulti3.setData(self.multiData)
         self.sparkMulti5.setData(self.multiData)
 

--- a/vindauga/widgets/sparkline.py
+++ b/vindauga/widgets/sparkline.py
@@ -77,6 +77,13 @@ class Sparkline(View):
         self.data = []
         self.drawView()
 
+    def _getScaleBounds(self) -> tuple[float, float]:
+        if self.autoScale:
+            return min(self.data), max(self.data)
+        minVal = self.minValue if self.minValue is not None else min(self.data)
+        maxVal = self.maxValue if self.maxValue is not None else max(self.data)
+        return minVal, maxVal
+
     def _normalizeValue(self, value: Union[int, float], minVal: float, maxVal: float) -> float:
         """
         Normalize a value to 0-1 range based on min/max.
@@ -125,13 +132,7 @@ class Sparkline(View):
             self.writeLine(0, y, self.size.x, 1, buf)
             return
 
-        # Determine min/max for scaling
-        if self.autoScale:
-            minVal = min(self.data)
-            maxVal = max(self.data)
-        else:
-            minVal = self.minValue if self.minValue is not None else min(self.data)
-            maxVal = self.maxValue if self.maxValue is not None else max(self.data)
+        minVal, maxVal = self._getScaleBounds()
 
         # Get the portion of data to display (rightmost points that fit)
         displayData = self.data[-self.size.x:] if len(self.data) > self.size.x else self.data
@@ -149,31 +150,21 @@ class Sparkline(View):
         buf.moveStr(0, sparkStr, color)
         self.writeLine(0, y, self.size.x, 1, buf)
 
-    def _drawMultiLine(self):
+    def _drawMultiLine(self, color: AttributePair):
         """
         Draw a multi-line sparkline with vertical resolution.
         """
         if not self.data:
-            # Empty sparkline - fill with spaces
             for y in range(self.size.y):
                 buf = DrawBuffer()
-                color = self.getColor(1)
                 buf.moveChar(0, self.BACK_CHAR, color, self.size.x)
                 self.writeLine(0, y, self.size.x, 1, buf)
             return
 
-        # Determine min/max for scaling
-        if self.autoScale:
-            minVal = min(self.data)
-            maxVal = max(self.data)
-        else:
-            minVal = self.minValue if self.minValue is not None else min(self.data)
-            maxVal = self.maxValue if self.maxValue is not None else max(self.data)
+        minVal, maxVal = self._getScaleBounds()
 
         # Get the portion of data to display
         displayData = self.data[-self.size.x:] if len(self.data) > self.size.x else self.data
-
-        color = self.getColor(1)
 
         # For multi-line, we need to think in terms of vertical blocks
         # Each column represents one data point
@@ -198,8 +189,8 @@ class Sparkline(View):
                     # This line is fully filled
                     lineStr += self.SPARK_CHARS[-1]
                 elif heightInSegments > baseHeight:
-                    # Partial fill
-                    partialSegments = int(heightInSegments - baseHeight)
+                    # Partial fill — clamp to at least 1 so we never emit a space here
+                    partialSegments = max(1, int(heightInSegments - baseHeight))
                     lineStr += self.SPARK_CHARS[partialSegments]
                 else:
                     # Empty
@@ -212,14 +203,12 @@ class Sparkline(View):
 
     def draw(self):
         """Draw the sparkline widget."""
+        color = self.getColor(1)
         if self.size.y == 1:
-            # Single line sparkline
             buf = DrawBuffer()
-            color = self.getColor(1)
             self._drawSingleLine(buf, 0, color)
         else:
-            # Multi-line sparkline with vertical resolution
-            self._drawMultiLine()
+            self._drawMultiLine(color)
 
     def getPalette(self) -> Palette:
         """Get the color palette for the sparkline."""

--- a/vindauga/widgets/wallpaper_background.py
+++ b/vindauga/widgets/wallpaper_background.py
@@ -45,7 +45,7 @@ class WallpaperBackground(Background):
     def draw(self):
         if self._drawLock:
             return
-        for y, line in enumerate(itertools.islice(self._char_lines, 0, max(len(self._char_lines), self.size.y))):
+        for y, line in enumerate(itertools.islice(self._char_lines, 0, min(len(self._char_lines), self.size.y))):
             self.writeLine(0, y, self.size.x, 1, line)
 
     def reload_image(self):


### PR DESCRIPTION
- sparkline: extract duplicated min/max scaling logic into _getScaleBounds()
- sparkline: fix multi-line partial-fill off-by-one (tiny values emitted space instead of the smallest block character)
- sparkline: centralize getColor(1) call in draw(), pass color to _drawMultiLine
- wallpaper_background: fix draw() using max() instead of min() in islice bound
- examples/sparklines: replace list.pop(0) O(n) pattern with deque(maxlen=100)